### PR TITLE
Updated Ubuntu image version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,13 @@ language: php
 php:
   - "7.3"
 
-dist: trusty
+dist: bionic
 
 services:
   - mysql
 
 addons:
   apt:
-    sources:
-      - mysql-5.7-trusty
     packages:
       - mysql-server
 


### PR DESCRIPTION
Updated Ubuntu image version because MySQL 5.7 is no longer supported with the initial image.